### PR TITLE
Feature/my page UI

### DIFF
--- a/core/presentation/designsystem/src/main/java/com/hyunjung/core/presentation/designsystem/component/CherrydanDefaultButton.kt
+++ b/core/presentation/designsystem/src/main/java/com/hyunjung/core/presentation/designsystem/component/CherrydanDefaultButton.kt
@@ -56,7 +56,7 @@ enum class CherrydanButtonShape(val cornerRadius: Dp) {
 
 enum class CherrydanButtonSize {
     SMALL,
-    BIG,
+    BIG
 }
 
 @Composable
@@ -77,7 +77,7 @@ fun CherrydanDefaultButton(
                     .height(36.dp)
                     .clip(RoundedCornerShape(shape.cornerRadius))
                     .background(if (enabled) style.containerColor else style.disabledContainerColor)
-                    .clickable { onClick() }
+                    .clickable(enabled = enabled, onClick = onClick)
             }
 
             CherrydanButtonSize.BIG -> {
@@ -85,7 +85,7 @@ fun CherrydanDefaultButton(
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(shape.cornerRadius))
                     .background(if (enabled) style.containerColor else style.disabledContainerColor)
-                    .clickable { onClick() }
+                    .clickable(enabled = enabled, onClick = onClick)
                     .padding(vertical = 15.dp)
             }
         },

--- a/core/presentation/designsystem/src/main/java/com/hyunjung/core/presentation/designsystem/component/CherrydanDefaultButton.kt
+++ b/core/presentation/designsystem/src/main/java/com/hyunjung/core/presentation/designsystem/component/CherrydanDefaultButton.kt
@@ -1,0 +1,196 @@
+package com.hyunjung.core.presentation.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hyunjung.core.presentation.designsystem.CherrydanColors
+import com.hyunjung.core.presentation.designsystem.CherrydanTheme
+import com.hyunjung.core.presentation.designsystem.CherrydanTypography
+
+enum class CherrydanButtonStyle(
+    val containerColor: Color,
+    val contentColor: Color,
+    val disabledContainerColor: Color,
+    val disabledContentColor: Color
+) {
+    GRAY(
+        containerColor = CherrydanColors.Gray2,
+        contentColor = CherrydanColors.Gray5,
+        disabledContainerColor = CherrydanColors.Gray2,
+        disabledContentColor = CherrydanColors.Gray5
+    ),
+    MAIN_PINK_2(
+        containerColor = CherrydanColors.MainPink2,
+        contentColor = CherrydanColors.White,
+        disabledContainerColor = CherrydanColors.MainPink1,
+        disabledContentColor = CherrydanColors.White
+    ),
+    MAIN_PINK_3(
+        containerColor = CherrydanColors.MainPink3,
+        contentColor = CherrydanColors.White,
+        disabledContainerColor = CherrydanColors.MainPink1,
+        disabledContentColor = CherrydanColors.White
+    )
+}
+
+enum class CherrydanButtonShape(val cornerRadius: Dp) {
+    ROUNDED_SMALL(2.dp),
+    ROUNDED_MEDIUM(4.dp)
+}
+
+enum class CherrydanButtonSize {
+    SMALL,
+    BIG,
+}
+
+@Composable
+fun CherrydanDefaultButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    style: CherrydanButtonStyle = CherrydanButtonStyle.GRAY,
+    shape: CherrydanButtonShape = CherrydanButtonShape.ROUNDED_SMALL,
+    size: CherrydanButtonSize = CherrydanButtonSize.BIG,
+    enabled: Boolean = true,
+    textStyle: TextStyle = CherrydanTypography.Main5_R
+) {
+    Box(
+        modifier = when (size) {
+            CherrydanButtonSize.SMALL -> {
+                modifier
+                    .height(36.dp)
+                    .clip(RoundedCornerShape(shape.cornerRadius))
+                    .background(if (enabled) style.containerColor else style.disabledContainerColor)
+                    .clickable { onClick() }
+            }
+
+            CherrydanButtonSize.BIG -> {
+                modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(shape.cornerRadius))
+                    .background(if (enabled) style.containerColor else style.disabledContainerColor)
+                    .clickable { onClick() }
+                    .padding(vertical = 15.dp)
+            }
+        },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            style = textStyle,
+            color = if (enabled) style.contentColor else style.disabledContentColor,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CherrydanGrayButtonPreview() {
+    CherrydanTheme {
+        CherrydanDefaultButton(
+            text = "Default Button",
+            onClick = {},
+            modifier = Modifier.fillMaxWidth(),
+            shape = CherrydanButtonShape.ROUNDED_MEDIUM,
+            enabled = true
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CherrydanPinkButtonPreview() {
+    CherrydanTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CherrydanDefaultButton(
+                text = "Pink1 Button",
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+                style = CherrydanButtonStyle.MAIN_PINK_2,
+                shape = CherrydanButtonShape.ROUNDED_MEDIUM,
+                enabled = false
+            )
+            CherrydanDefaultButton(
+                text = "Pink2 Button",
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+                style = CherrydanButtonStyle.MAIN_PINK_2,
+                shape = CherrydanButtonShape.ROUNDED_MEDIUM,
+                enabled = true
+            )
+            CherrydanDefaultButton(
+                text = "Pink3 Button",
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+                style = CherrydanButtonStyle.MAIN_PINK_3,
+                shape = CherrydanButtonShape.ROUNDED_MEDIUM,
+                enabled = true
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CherrydanSmallButtonPreview() {
+    CherrydanTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CherrydanDefaultButton(
+                text = "Gray Button",
+                onClick = {},
+                modifier = Modifier,
+                style = CherrydanButtonStyle.GRAY,
+                shape = CherrydanButtonShape.ROUNDED_SMALL,
+                size = CherrydanButtonSize.SMALL,
+                enabled = true
+            )
+            CherrydanDefaultButton(
+                text = "Pink1 Button",
+                onClick = {},
+                modifier = Modifier,
+                style = CherrydanButtonStyle.MAIN_PINK_2,
+                shape = CherrydanButtonShape.ROUNDED_SMALL,
+                size = CherrydanButtonSize.SMALL,
+                enabled = false
+            )
+            CherrydanDefaultButton(
+                text = "Pink2 Button",
+                onClick = {},
+                modifier = Modifier,
+                style = CherrydanButtonStyle.MAIN_PINK_2,
+                shape = CherrydanButtonShape.ROUNDED_SMALL,
+                size = CherrydanButtonSize.SMALL,
+                enabled = true
+            )
+            CherrydanDefaultButton(
+                text = "Pink3 Button",
+                onClick = {},
+                modifier = Modifier,
+                style = CherrydanButtonStyle.MAIN_PINK_3,
+                shape = CherrydanButtonShape.ROUNDED_SMALL,
+                size = CherrydanButtonSize.SMALL,
+                enabled = true
+            )
+        }
+    }
+}

--- a/core/presentation/ui/src/main/res/values/strings.xml
+++ b/core/presentation/ui/src/main/res/values/strings.xml
@@ -48,12 +48,12 @@
     <string name="search_toast_cannot_keyword_2">(마이페이지 > 내 정보 > 키워드 알림)에서 확인해 주세요.</string>
 
     <!-- My Page Screen -->
-    <string name="mypage_title">마이페이지</string>
-    <string name="mypage_greeting"> 체리님 안녕하세요</string>
-    <string name="mypage_version">버전 정보</string>
-    <string name="mypage_privacy_policy">개인정보 처리방침</string>
-    <string name="mypage_terms_and_conditions">이용약관</string>
-    <string name="mypage_management_policy">운영정책</string>
-    <string name="mypage_withdrawal">회원 탈퇴</string>
-    <string name="mypage_logout">로그아웃</string>
+    <string name="my_page_title">마이페이지</string>
+    <string name="my_page_greeting"> 체리님 안녕하세요</string>
+    <string name="my_page_version">버전 정보</string>
+    <string name="my_page_privacy_policy">개인정보 처리방침</string>
+    <string name="my_page_terms_and_conditions">이용약관</string>
+    <string name="my_page_management_policy">운영정책</string>
+    <string name="my_page_withdrawal">회원 탈퇴</string>
+    <string name="my_page_logout">로그아웃</string>
 </resources>

--- a/core/presentation/ui/src/main/res/values/strings.xml
+++ b/core/presentation/ui/src/main/res/values/strings.xml
@@ -50,6 +50,11 @@
     <!-- My Page Screen -->
     <string name="my_page_title">마이페이지</string>
     <string name="my_page_greeting"> 체리님 안녕하세요</string>
+    <string name="my_page_customer_center">고객 센터</string>
+    <string name="my_page_notice">공지 사항</string>
+    <string name="my_page_inquiry">1:1 문의</string>
+    <string name="my_page_faq">자주 묻는 질문</string>
+    <string name="my_page_guide">이용 가이드</string>
     <string name="my_page_service_setting">서비스 설정</string>
     <string name="my_page_notification_setting">알림 설정</string>
     <string name="my_page_version_info">버전 정보</string>

--- a/core/presentation/ui/src/main/res/values/strings.xml
+++ b/core/presentation/ui/src/main/res/values/strings.xml
@@ -50,10 +50,12 @@
     <!-- My Page Screen -->
     <string name="my_page_title">마이페이지</string>
     <string name="my_page_greeting"> 체리님 안녕하세요</string>
-    <string name="my_page_version">버전 정보</string>
+    <string name="my_page_service_setting">서비스 설정</string>
+    <string name="my_page_notification_setting">알림 설정</string>
+    <string name="my_page_version_info">버전 정보</string>
     <string name="my_page_privacy_policy">개인정보 처리방침</string>
     <string name="my_page_terms_and_conditions">이용약관</string>
     <string name="my_page_management_policy">운영정책</string>
-    <string name="my_page_withdrawal">회원 탈퇴</string>
+    <string name="my_page_withdrawal">회원탈퇴</string>
     <string name="my_page_logout">로그아웃</string>
 </resources>

--- a/core/presentation/ui/src/main/res/values/strings.xml
+++ b/core/presentation/ui/src/main/res/values/strings.xml
@@ -46,4 +46,14 @@
     <string name="search_toast_keyword">키워드 알림을 추가했어요.</string>
     <string name="search_toast_cannot_keyword_1">키워드 알림을 더이상 추가할 수 없어요.</string>
     <string name="search_toast_cannot_keyword_2">(마이페이지 > 내 정보 > 키워드 알림)에서 확인해 주세요.</string>
+
+    <!-- My Page Screen -->
+    <string name="mypage_title">마이페이지</string>
+    <string name="mypage_greeting"> 체리님 안녕하세요</string>
+    <string name="mypage_version">버전 정보</string>
+    <string name="mypage_privacy_policy">개인정보 처리방침</string>
+    <string name="mypage_terms_and_conditions">이용약관</string>
+    <string name="mypage_management_policy">운영정책</string>
+    <string name="mypage_withdrawal">회원 탈퇴</string>
+    <string name="mypage_logout">로그아웃</string>
 </resources>

--- a/home/presentation/src/main/java/com/hyunjung/home/presentation/my_page/MyPageScreen.kt
+++ b/home/presentation/src/main/java/com/hyunjung/home/presentation/my_page/MyPageScreen.kt
@@ -1,16 +1,235 @@
 package com.hyunjung.home.presentation.my_page
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.hyunjung.core.presentation.designsystem.ArrowRightIcon
 import com.hyunjung.core.presentation.designsystem.CherrydanColors
+import com.hyunjung.core.presentation.designsystem.CherrydanTheme
 import com.hyunjung.core.presentation.designsystem.CherrydanTypography
+import com.hyunjung.core.presentation.designsystem.NotificationIcon
+import com.hyunjung.core.presentation.designsystem.SearchIcon
+import com.hyunjung.core.presentation.designsystem.component.CherrydanTopAppBar
+import com.hyunjung.core.presentation.designsystem.component.TopBarIconButton
+import com.hyunjung.core.presentation.ui.R
 
 @Composable
 fun MyPageScreen(modifier: Modifier = Modifier) {
-    Text(
-        text = "마이페이지",
-        style = CherrydanTypography.Title1,
-        color = CherrydanColors.Black
-    )
+    Scaffold(
+        modifier = modifier,
+        containerColor = CherrydanColors.White,
+        contentColor = CherrydanColors.Black,
+        topBar = {
+            CherrydanTopAppBar(
+                title = stringResource(id = R.string.my_page_title),
+                navigationIcon = null,
+                actions = {
+                    TopBarIconButton(
+                        imageVector = NotificationIcon,
+                        contentDescription = "알림",
+                        onClick = {}
+                    )
+                    TopBarIconButton(
+                        imageVector = SearchIcon,
+                        contentDescription = "검색",
+                        onClick = {}
+                    )
+                }
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 20.dp)
+                        .background(CherrydanColors.PointBeige, shape = RoundedCornerShape(4.dp))
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 11.dp, vertical = 44.dp)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.my_page_greeting),
+                            style = CherrydanTypography.Title4,
+                            modifier = Modifier.align(Alignment.CenterVertically)
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        Icon(
+                            imageVector = ArrowRightIcon,
+                            contentDescription = null,
+                        )
+                    }
+                }
+            }
+            item {
+                Text(
+                    text = "고객 센터",
+                    style = CherrydanTypography.Main5_B,
+                    color = CherrydanColors.MainPink2,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = "공지 사항"
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = "1:1 문의"
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = "자주 묻는 질문"
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = "이용 가이드"
+                )
+            }
+            item {
+                HorizontalDivider(
+                    modifier = Modifier.padding(16.dp),
+                    color = CherrydanColors.Gray2,
+                    thickness = 1.dp
+                )
+            }
+            item {
+                Text(
+                    text = stringResource(id = R.string.my_page_service_setting),
+                    style = CherrydanTypography.Main5_B,
+                    color = CherrydanColors.MainPink2,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = stringResource(id = R.string.my_page_notification_setting)
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = stringResource(id = R.string.my_page_version_info)
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = stringResource(id = R.string.my_page_privacy_policy)
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = stringResource(id = R.string.my_page_terms_and_conditions)
+                )
+            }
+            item {
+                MyPageItemText(
+                    text = stringResource(id = R.string.my_page_management_policy)
+                )
+            }
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Button(
+                        onClick = { /* TODO: Handle logout */ },
+                        modifier = Modifier
+                            .padding(end = 8.dp),
+                        contentPadding = PaddingValues(horizontal = 18.dp, vertical = 9.dp),
+                        colors = ButtonColors(
+                            containerColor = CherrydanColors.Gray2,
+                            contentColor = CherrydanColors.Gray5,
+                            disabledContainerColor = CherrydanColors.Gray2,
+                            disabledContentColor = CherrydanColors.Gray5
+                        ),
+                        shape = RoundedCornerShape(2.dp)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.my_page_withdrawal),
+                            style = CherrydanTypography.Main5_R,
+                            color = CherrydanColors.Gray5
+                        )
+                    }
+                    Button(
+                        onClick = { /* TODO: Handle logout */ },
+                        contentPadding = PaddingValues(horizontal = 18.dp, vertical = 9.dp),
+                        colors = ButtonColors(
+                            containerColor = CherrydanColors.Gray2,
+                            contentColor = CherrydanColors.Gray5,
+                            disabledContainerColor = CherrydanColors.Gray2,
+                            disabledContentColor = CherrydanColors.Gray5
+                        ),
+                        shape = RoundedCornerShape(2.dp)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.my_page_logout),
+                            style = CherrydanTypography.Main5_R,
+                            color = CherrydanColors.Gray5
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MyPageItemText(text: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = text,
+            style = CherrydanTypography.Main2_R,
+            color = CherrydanColors.Black
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MyPageScreenPreview() {
+    CherrydanTheme {
+        MyPageScreen()
+    }
 }

--- a/home/presentation/src/main/java/com/hyunjung/home/presentation/my_page/MyPageScreen.kt
+++ b/home/presentation/src/main/java/com/hyunjung/home/presentation/my_page/MyPageScreen.kt
@@ -91,7 +91,7 @@ fun MyPageScreen(modifier: Modifier = Modifier) {
             }
             item {
                 Text(
-                    text = "고객 센터",
+                    text = stringResource(R.string.my_page_customer_center),
                     style = CherrydanTypography.Main5_B,
                     color = CherrydanColors.MainPink2,
                     modifier = Modifier
@@ -101,22 +101,22 @@ fun MyPageScreen(modifier: Modifier = Modifier) {
             }
             item {
                 MyPageItemText(
-                    text = "공지 사항"
+                    text = stringResource(R.string.my_page_notice)
                 )
             }
             item {
                 MyPageItemText(
-                    text = "1:1 문의"
+                    text = stringResource(id = R.string.my_page_inquiry)
                 )
             }
             item {
                 MyPageItemText(
-                    text = "자주 묻는 질문"
+                    text = stringResource(id = R.string.my_page_faq)
                 )
             }
             item {
                 MyPageItemText(
-                    text = "이용 가이드"
+                    text = stringResource(id = R.string.my_page_guide)
                 )
             }
             item {

--- a/home/presentation/src/main/java/com/hyunjung/home/presentation/my_page/MyPageScreen.kt
+++ b/home/presentation/src/main/java/com/hyunjung/home/presentation/my_page/MyPageScreen.kt
@@ -3,16 +3,14 @@ package com.hyunjung.home.presentation.my_page
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -29,6 +27,9 @@ import com.hyunjung.core.presentation.designsystem.CherrydanTheme
 import com.hyunjung.core.presentation.designsystem.CherrydanTypography
 import com.hyunjung.core.presentation.designsystem.NotificationIcon
 import com.hyunjung.core.presentation.designsystem.SearchIcon
+import com.hyunjung.core.presentation.designsystem.component.CherrydanButtonShape
+import com.hyunjung.core.presentation.designsystem.component.CherrydanButtonSize
+import com.hyunjung.core.presentation.designsystem.component.CherrydanDefaultButton
 import com.hyunjung.core.presentation.designsystem.component.CherrydanTopAppBar
 import com.hyunjung.core.presentation.designsystem.component.TopBarIconButton
 import com.hyunjung.core.presentation.ui.R
@@ -168,42 +169,23 @@ fun MyPageScreen(modifier: Modifier = Modifier) {
                         .padding(16.dp),
                     horizontalArrangement = Arrangement.End
                 ) {
-                    Button(
+                    CherrydanDefaultButton(
+                        text = stringResource(id = R.string.my_page_withdrawal),
+                        onClick = { /* TODO: Handle withdrawal */ },
+                        modifier = Modifier
+                            .width(80.dp)
+                            .padding(end = 8.dp),
+                        shape = CherrydanButtonShape.ROUNDED_SMALL,
+                        size = CherrydanButtonSize.SMALL
+                    )
+                    CherrydanDefaultButton(
+                        text = stringResource(id = R.string.my_page_logout),
                         onClick = { /* TODO: Handle logout */ },
                         modifier = Modifier
-                            .padding(end = 8.dp),
-                        contentPadding = PaddingValues(horizontal = 18.dp, vertical = 9.dp),
-                        colors = ButtonColors(
-                            containerColor = CherrydanColors.Gray2,
-                            contentColor = CherrydanColors.Gray5,
-                            disabledContainerColor = CherrydanColors.Gray2,
-                            disabledContentColor = CherrydanColors.Gray5
-                        ),
-                        shape = RoundedCornerShape(2.dp)
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.my_page_withdrawal),
-                            style = CherrydanTypography.Main5_R,
-                            color = CherrydanColors.Gray5
-                        )
-                    }
-                    Button(
-                        onClick = { /* TODO: Handle logout */ },
-                        contentPadding = PaddingValues(horizontal = 18.dp, vertical = 9.dp),
-                        colors = ButtonColors(
-                            containerColor = CherrydanColors.Gray2,
-                            contentColor = CherrydanColors.Gray5,
-                            disabledContainerColor = CherrydanColors.Gray2,
-                            disabledContentColor = CherrydanColors.Gray5
-                        ),
-                        shape = RoundedCornerShape(2.dp)
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.my_page_logout),
-                            style = CherrydanTypography.Main5_R,
-                            color = CherrydanColors.Gray5
-                        )
-                    }
+                            .width(80.dp),
+                        shape = CherrydanButtonShape.ROUNDED_SMALL,
+                        size = CherrydanButtonSize.SMALL
+                    )
                 }
             }
         }

--- a/home/presentation/src/main/java/com/hyunjung/home/presentation/my_page/MyPageScreen.kt
+++ b/home/presentation/src/main/java/com/hyunjung/home/presentation/my_page/MyPageScreen.kt
@@ -1,6 +1,7 @@
 package com.hyunjung.home.presentation.my_page
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -193,11 +194,15 @@ fun MyPageScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun MyPageItemText(text: String) {
+private fun MyPageItemText(
+    text: String,
+    onClick: (() -> Unit)? = null
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .run { if (onClick != null) clickable { onClick() } else this },
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(


### PR DESCRIPTION
# PULL REQUEST

## Description
- Implemented MyPageScreen UI with user profile section
- Created menu items for account settings, notifications, and help
- Applied consistent design system and styling
- Implement `CherrydanDefaultButton` component

## ScreenShots
<p>
  <img src="https://github.com/user-attachments/assets/cf0e2c43-4431-47d6-84af-7c95c4871bb0", width="300" />
</p>
<p>
  <img src="https://github.com/user-attachments/assets/f53d01b3-7c74-41b7-b686-570b1e604620", width="50%" />
  <img src="https://github.com/user-attachments/assets/2378c52d-7d8c-4355-aadf-12deb6c361f8", width="50%" />
</p>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a redesigned "My Page" screen with a structured layout, including a top app bar, greeting section, customer center options, service settings, and dedicated buttons for account withdrawal and logout.
  * Added new string resources to support the updated "My Page" screen content and labels.
  * Added customizable button components with various styles, shapes, sizes, and enabled states for consistent UI elements across the app.

* **Style**
  * Enhanced visual styling and consistent theming across the "My Page" screen for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->